### PR TITLE
ignore v15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bower_cmps/
 *.sln.docstates
 *.sln.ide/
 applicationhost.config
+v15/
 
 # NServiceBus Logs
 nsb_log_*.txt


### PR DESCRIPTION
VS2017 respects the VS2015 .suo file, but it then creates its own version of it in a `v15` folder. There's no need for us to commit these files, until we switch to VS2017 as the minimum supported version.