### PR TITLE
remove the agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,35 +57,3 @@ NOTE: In case the database setup script fails with a "sqllocaldb command not fou
 ### Nuget packages restore
 
 The exercises are composed of 8 different Visual Studio solutions. All the solutions stored on GitHub rely upon `Nuget package restore` to be run at the first build. Please verify with the workshop organizers if internet access is available at the venue. It is required to run the Nuget restore, otherwise be sure to run the `Nuget package restore` for each solution before attending the workshop.
-
-## Agenda 
-### Day 1
-| Time  | Content |
-| ------------- | ------------- |
-|08:30-09:00| Computer setup time |
-|09:00-10:15| Lecture |
-|10:15-10:30| Break|
-|10:30-11:45| Coding session 1 - UI decomposition|
-|11:45-12:30| Lunch|
-|12:30-13:30| Summary Lecture Q&A|
-|13:30-13:45| Break|
-|13:45-15:00| Lecture – new topic|
-|15:00-15:15| Break|
-|15:15-16:15| Coding session 2 - Publish/subscribe event-processing interactions|
-|16:15-16:30| Break|
-|16:30-17:15| Summary Lecture Q&A|
-
-### Day 2
-| Time  | Content |
-| ------------- | ------------- |
-|09:00-10:15| Lecture |
-|10:15-10:30| Break|
-|10:30-11:45| Coding session 3 - Sagas: Long-running multi-stage business processes and policies|
-|11:45-12:30| Lunch|
-|12:30-13:30| Summary Lecture Q&A|
-|13:30-13:45| Break|
-|13:45-15:00| Lecture – new topic|
-|15:00-15:15| Break|
-|15:15-16:15| Coding session 4 - Commands and Reliable integration with 3rd party systems|
-|16:15-16:30| Break|
-|16:30-17:15| Summary Lecture Q&A|


### PR DESCRIPTION
It changes every time, and is handed out to the attendees.

@Particular/microservices-workshop-maintainers please review - would be good if we can merge this ASAP so that today's attendees are not confused with two different agendas.