### PR TITLE
Remove pagination support

### DIFF
--- a/exercises/01-composite-ui/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/01-composite-ui/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/01-composite-ui/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/01-composite-ui/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -10,7 +10,7 @@
                 ctrl.orders = null;
 
                 ctrl.isLoading = backendCompositionService
-                    .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                    .get('orders-list')
                     .then(function (viewModel) {
                         ctrl.orders = viewModel.orders;
                     })

--- a/exercises/01-composite-ui/after/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/01-composite-ui/after/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -17,7 +17,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             var orders = _context.Orders
                 .Include(i => i.Items)
@@ -25,8 +25,6 @@ namespace Divergent.Sales.API.Controllers
                 .ToArray();
 
             return orders
-                .Skip(p * s)
-                .Take(s)
                 .Select(o => new
                 {
                     o.Id,

--- a/exercises/01-composite-ui/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/01-composite-ui/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/01-composite-ui/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/01-composite-ui/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -10,7 +10,7 @@
                 ctrl.orders = null;
 
                 ctrl.isLoading = backendCompositionService
-                    .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                    .get('orders-list')
                     .then(function (viewModel) {
                         ctrl.orders = viewModel.orders;
                     })

--- a/exercises/01-composite-ui/before/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/01-composite-ui/before/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -17,7 +17,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             var orders = _context.Orders
                 .Include(i => i.Items)
@@ -25,8 +25,6 @@ namespace Divergent.Sales.API.Controllers
                 .ToArray();
 
             return orders
-                .Skip(p * s)
-                .Take(s)
                 .Select(o => new
                 {
                     o.Id,

--- a/exercises/02-publish-subscribe/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/02-publish-subscribe/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/02-publish-subscribe/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/02-publish-subscribe/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -11,7 +11,7 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = backendCompositionService
-                        .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                        .get('orders-list')
                         .then(function (viewModel) {
                             ctrl.orders = viewModel.orders;
                         })

--- a/exercises/02-publish-subscribe/after/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -37,7 +37,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             using (var _context = new SalesContext())
             {
@@ -47,8 +47,6 @@ namespace Divergent.Sales.API.Controllers
                 .ToArray();
 
                 return orders
-                    .Skip(p * s)
-                    .Take(s)
                     .Select(o => new
                     {
                         o.Id,

--- a/exercises/02-publish-subscribe/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/02-publish-subscribe/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/02-publish-subscribe/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/02-publish-subscribe/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -11,7 +11,7 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = backendCompositionService
-                        .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                        .get('orders-list')
                         .then(function (viewModel) {
                             ctrl.orders = viewModel.orders;
                         })

--- a/exercises/02-publish-subscribe/before/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/02-publish-subscribe/before/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -37,7 +37,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             using (var _context = new SalesContext())
             {
@@ -47,8 +47,6 @@ namespace Divergent.Sales.API.Controllers
                 .ToArray();
 
                 return orders
-                    .Skip(p * s)
-                    .Take(s)
                     .Select(o => new
                     {
                         o.Id,

--- a/exercises/03-sagas/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/03-sagas/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/03-sagas/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/03-sagas/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -11,7 +11,7 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = backendCompositionService
-                        .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                        .get('orders-list')
                         .then(function (viewModel) {
                             ctrl.orders = viewModel.orders;
                         })

--- a/exercises/03-sagas/after/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/03-sagas/after/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -37,7 +37,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             using (var _context = new SalesContext())
             {
@@ -47,8 +47,6 @@ namespace Divergent.Sales.API.Controllers
                     .ToArray();
 
                 return orders
-                    .Skip(p * s)
-                    .Take(s)
                     .Select(o => new
                     {
                         o.Id,

--- a/exercises/03-sagas/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/03-sagas/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/03-sagas/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/03-sagas/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -11,7 +11,7 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = backendCompositionService
-                        .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                        .get('orders-list')
                         .then(function (viewModel) {
                             ctrl.orders = viewModel.orders;
                         })

--- a/exercises/03-sagas/before/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/03-sagas/before/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -37,7 +37,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             using (var _context = new SalesContext())
             {
@@ -47,8 +47,6 @@ namespace Divergent.Sales.API.Controllers
                     .ToArray();
 
                 return orders
-                    .Skip(p * s)
-                    .Take(s)
                     .Select(o => new
                     {
                         o.Id,

--- a/exercises/04-integration/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/04-integration/after/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/04-integration/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/04-integration/after/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -11,7 +11,7 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = backendCompositionService
-                        .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                        .get('orders-list')
                         .then(function (viewModel) {
                             ctrl.orders = viewModel.orders;
                         })

--- a/exercises/04-integration/after/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/04-integration/after/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -37,7 +37,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             using (var _context = new SalesContext())
             {
@@ -47,8 +47,6 @@ namespace Divergent.Sales.API.Controllers
                     .ToArray();
 
                 return orders
-                    .Skip(p * s)
-                    .Take(s)
                     .Select(o => new
                     {
                         o.Id,

--- a/exercises/04-integration/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
+++ b/exercises/04-integration/before/Divergent.Frontend/app/modules/sales/orderListAppender.js
@@ -11,7 +11,7 @@
                         var appender = {
                             append: function (args, viewModel) {
 
-                                var uri = config.apiUrl + '/orders?p=' + args.pageIndex + '&s=' + args.pageSize;
+                                var uri = config.apiUrl + '/orders';
                                 return $http.get(uri)
                                     .then(function (response) {
 

--- a/exercises/04-integration/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
+++ b/exercises/04-integration/before/Divergent.Frontend/app/modules/sales/orders/ordersController.js
@@ -11,7 +11,7 @@
 
                 ctrl.refreshOrders = function () {
                     ctrl.isLoading = backendCompositionService
-                        .get('orders-list', { pageIndex: 0, pageSize: 10 })
+                        .get('orders-list')
                         .then(function (viewModel) {
                             ctrl.orders = viewModel.orders;
                         })

--- a/exercises/04-integration/before/Divergent.Sales.API/Controllers/OrdersController.cs
+++ b/exercises/04-integration/before/Divergent.Sales.API/Controllers/OrdersController.cs
@@ -37,7 +37,7 @@ namespace Divergent.Sales.API.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<dynamic> Get(int p = 0, int s = 10)
+        public IEnumerable<dynamic> Get()
         {
             using (var _context = new SalesContext())
             {
@@ -47,8 +47,6 @@ namespace Divergent.Sales.API.Controllers
                     .ToArray();
 
                 return orders
-                    .Skip(p * s)
-                    .Take(s)
                     .Select(o => new
                     {
                         o.Id,


### PR DESCRIPTION
Front end lists in workshop exercises are limited to 10 items. This means that if you test one of the exercises a few times, your latest changes are not shown, and it appears as though the solution isn't working.