### PR TITLE
Update build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,8 +5,7 @@ setlocal
 
 :: set tool versions
 set NUGET_VERSION=4.3.0
-set MSBUILD_VERSION=15
-set CSI_VERSION=2.3.2
+set CSI_VERSION=2.4.0
 
 :: determine nuget cache dir
 set NUGET_CACHE_DIR=%LocalAppData%\.nuget\v%NUGET_VERSION%
@@ -15,21 +14,26 @@ set NUGET_LOCAL_DIR=.nuget\v%NUGET_VERSION%
 :: download nuget to cache dir
 set NUGET_URL=https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/NuGet.exe
 if not exist %NUGET_CACHE_DIR%\NuGet.exe (
-  if not exist %NUGET_CACHE_DIR% mkdir %NUGET_CACHE_DIR%
+  if not exist %NUGET_CACHE_DIR% mkdir %NUGET_CACHE_DIR% || goto :error
   echo Downloading '%NUGET_URL%'' to '%NUGET_CACHE_DIR%\NuGet.exe'...
   @powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest '%NUGET_URL%' -OutFile '%NUGET_CACHE_DIR%\NuGet.exe'"
 )
 
 :: copy nuget locally
 if not exist %NUGET_LOCAL_DIR%\NuGet.exe (
-  if not exist %NUGET_LOCAL_DIR% mkdir %NUGET_LOCAL_DIR%
-  copy %NUGET_CACHE_DIR%\NuGet.exe %NUGET_LOCAL_DIR%\NuGet.exe > nul
+  if not exist %NUGET_LOCAL_DIR% mkdir %NUGET_LOCAL_DIR% || goto :error
+  copy %NUGET_CACHE_DIR%\NuGet.exe %NUGET_LOCAL_DIR%\NuGet.exe > nul || goto :error
 )
 
 :: restore packages for build script
 echo Restoring NuGet packages for build script...
-%NUGET_LOCAL_DIR%\NuGet.exe restore .\packages.config -PackagesDirectory ./packages
+%NUGET_LOCAL_DIR%\NuGet.exe restore .\packages.config -PackagesDirectory ./packages || goto :error
 
 :: run build script
 echo Running build script...
-".\packages\Microsoft.Net.Compilers.%CSI_VERSION%\tools\csi.exe" .\build.csx %*
+.\packages\Microsoft.Net.Compilers.%CSI_VERSION%\tools\csi.exe .\build.csx %* || goto :error
+
+:: exit
+goto :EOF
+:error
+exit /b %errorlevel%

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="2.3.2" />
+  <package id="Microsoft.Net.Compilers" version="2.4.0" />
   <package id="simple-targets-csx" version="6.0.0" />
   <package id="vswhere" version="2.1.4" />
 </packages>


### PR DESCRIPTION
- Stop swallowing errors
- Upgrade to csi 2.4.0
- Remove redundant MSBUILD_VERSION

Based on the canonical version I keep at https://gist.github.com/adamralph/c86eaf694c45ec4f8b6748eb3f13221d/1af0811b74096317e2ada84717920468c50bec83