### PR TITLE
remove redundant compiler warnings

### DIFF
--- a/exercises/01-composite-ui/after/Divergent.Customers.Data/Repositories/CustomerOrderRepository.cs
+++ b/exercises/01-composite-ui/after/Divergent.Customers.Data/Repositories/CustomerOrderRepository.cs
@@ -7,9 +7,9 @@ namespace Divergent.Customers.Data.Repositories
 {
     public class CustomerOrderRepository
     {
-        public async Task<List<CustomerOrderRelationship>> CustomerOrderRelationships()
+        public Task<List<CustomerOrderRelationship>> CustomerOrderRelationships()
         {
-            return SeedCustomerOrderRelationship();
+            return Task.FromResult(SeedCustomerOrderRelationship());
         }
 
         private List<CustomerOrderRelationship> SeedCustomerOrderRelationship()

--- a/exercises/01-composite-ui/after/Divergent.Customers.Data/Repositories/CustomerRepository.cs
+++ b/exercises/01-composite-ui/after/Divergent.Customers.Data/Repositories/CustomerRepository.cs
@@ -8,14 +8,14 @@ namespace Divergent.Customers.Data.Repositories
 {
     public class CustomerRepository : ICustomerRepository
     {
-        public async Task<List<Customer>> Customers()
+        public Task<List<Customer>> Customers()
         {
-            return SeedCustomers();
+            return Task.FromResult(SeedCustomers());
         }
 
-        public async Task<Customer> Customer(Guid id)
+        public Task<Customer> Customer(Guid id)
         {
-            return SeedCustomers().First(s => s.Id == id);
+            return Task.FromResult(SeedCustomers().First(s => s.Id == id));
         }
 
         private List<Customer> SeedCustomers()

--- a/exercises/01-composite-ui/after/Divergent.Finance.Data/Repositories/FinanceRepository.cs
+++ b/exercises/01-composite-ui/after/Divergent.Finance.Data/Repositories/FinanceRepository.cs
@@ -8,14 +8,14 @@ namespace Divergent.Finance.Data.Repositories
 {
     public class FinanceRepository : IFinanceRepository
     {
-        public async Task<List<Price>> Prices()
+        public Task<List<Price>> Prices()
         {
-            return SeedPrices();
+            return Task.FromResult(SeedPrices());
         }
 
-        public async Task<Price> Price(Guid productId)
+        public Task<Price> Price(Guid productId)
         {
-            return SeedPrices().First(s => s.ProductId == productId);
+            return Task.FromResult(SeedPrices().First(s => s.ProductId == productId));
         }
 
         private List<Price> SeedPrices()

--- a/exercises/01-composite-ui/after/Divergent.Finance.Data/Repositories/OrdersTotalRepository.cs
+++ b/exercises/01-composite-ui/after/Divergent.Finance.Data/Repositories/OrdersTotalRepository.cs
@@ -7,9 +7,9 @@ namespace Divergent.Finance.Data.Repositories
 {
     public class OrdersTotalRepository
     {
-        public async Task<List<OrderTotalPrice>> OrderTotalPrices()
+        public Task<List<OrderTotalPrice>> OrderTotalPrices()
         {
-            return SeedOrderTotalPrices();
+            return Task.FromResult(SeedOrderTotalPrices());
         }
 
         private List<OrderTotalPrice> SeedOrderTotalPrices()

--- a/exercises/01-composite-ui/after/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/01-composite-ui/after/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/01-composite-ui/after/Divergent.Sales.Data/Repositories/OrderRepository.cs
+++ b/exercises/01-composite-ui/after/Divergent.Sales.Data/Repositories/OrderRepository.cs
@@ -18,9 +18,9 @@ namespace Divergent.Sales.Data.Repositories
         internal static Product theForceAwakensProduct = new Product { Id = theForceAwakens, Name = "Star Wars : The Force Awakens" };
         internal static Product aNewHopeProduct = new Product { Id = aNewHope, Name = "Star Wars : A New Hope" };
 
-        public async Task<List<Order>> Orders()
+        public Task<List<Order>> Orders()
         {
-            return OrderSeedData();
+            return Task.FromResult(OrderSeedData());
         }
 
         internal static List<Product> Products()

--- a/exercises/01-composite-ui/before/Divergent.Customers.Data/Repositories/CustomerOrderRepository.cs
+++ b/exercises/01-composite-ui/before/Divergent.Customers.Data/Repositories/CustomerOrderRepository.cs
@@ -7,9 +7,9 @@ namespace Divergent.Customers.Data.Repositories
 {
     public class CustomerOrderRepository
     {
-        public async Task<List<CustomerOrderRelationship>> CustomerOrderRelationships()
+        public Task<List<CustomerOrderRelationship>> CustomerOrderRelationships()
         {
-            return SeedCustomerOrderRelationship();
+            return Task.FromResult(SeedCustomerOrderRelationship());
         }
 
         private List<CustomerOrderRelationship> SeedCustomerOrderRelationship()

--- a/exercises/01-composite-ui/before/Divergent.Customers.Data/Repositories/CustomerRepository.cs
+++ b/exercises/01-composite-ui/before/Divergent.Customers.Data/Repositories/CustomerRepository.cs
@@ -8,14 +8,14 @@ namespace Divergent.Customers.Data.Repositories
 {
     public class CustomerRepository : ICustomerRepository
     {
-        public async Task<List<Customer>> Customers()
+        public Task<List<Customer>> Customers()
         {
-            return SeedCustomers();
+            return Task.FromResult(SeedCustomers());
         }
 
-        public async Task<Customer> Customer(Guid id)
+        public Task<Customer> Customer(Guid id)
         {
-            return SeedCustomers().First(s => s.Id == id);
+            return Task.FromResult(SeedCustomers().First(s => s.Id == id));
         }
 
         private List<Customer> SeedCustomers()

--- a/exercises/01-composite-ui/before/Divergent.Finance.Data/Repositories/FinanceRepository.cs
+++ b/exercises/01-composite-ui/before/Divergent.Finance.Data/Repositories/FinanceRepository.cs
@@ -8,14 +8,14 @@ namespace Divergent.Finance.Data.Repositories
 {
     public class FinanceRepository : IFinanceRepository
     {
-        public async Task<List<Price>> Prices()
+        public Task<List<Price>> Prices()
         {
-            return SeedPrices();
+            return Task.FromResult(SeedPrices());
         }
 
-        public async Task<Price> Price(Guid productId)
+        public Task<Price> Price(Guid productId)
         {
-            return SeedPrices().First(s => s.ProductId == productId);
+            return Task.FromResult(SeedPrices().First(s => s.ProductId == productId));
         }
 
         private List<Price> SeedPrices()

--- a/exercises/01-composite-ui/before/Divergent.Finance.Data/Repositories/OrdersTotalRepository.cs
+++ b/exercises/01-composite-ui/before/Divergent.Finance.Data/Repositories/OrdersTotalRepository.cs
@@ -7,9 +7,9 @@ namespace Divergent.Finance.Data.Repositories
 {
     public class OrdersTotalRepository
     {
-        public async Task<List<OrderTotalPrice>> OrderTotalPrices()
+        public Task<List<OrderTotalPrice>> OrderTotalPrices()
         {
-            return SeedOrderTotalPrices();
+            return Task.FromResult(SeedOrderTotalPrices());
         }
 
         private List<OrderTotalPrice> SeedOrderTotalPrices()

--- a/exercises/01-composite-ui/before/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/01-composite-ui/before/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/01-composite-ui/before/Divergent.Sales.Data/Repositories/OrderRepository.cs
+++ b/exercises/01-composite-ui/before/Divergent.Sales.Data/Repositories/OrderRepository.cs
@@ -18,9 +18,9 @@ namespace Divergent.Sales.Data.Repositories
         internal static Product theForceAwakensProduct = new Product { Id = theForceAwakens, Name = "Star Wars : The Force Awakens" };
         internal static Product aNewHopeProduct = new Product { Id = aNewHope, Name = "Star Wars : A New Hope" };
 
-        public async Task<List<Order>> Orders()
+        public Task<List<Order>> Orders()
         {
-            return OrderSeedData();
+            return Task.FromResult(OrderSeedData());
         }
 
         internal static List<Product> Products()

--- a/exercises/02-publish-subscribe/README.md
+++ b/exercises/02-publish-subscribe/README.md
@@ -117,6 +117,7 @@ namespace Divergent.Shipping.Handlers
         public async Task Handle(OrderSubmittedEvent message, IMessageHandlerContext context)
         {
             Log.Info("Handle");
+            await Task.CompletedTask;
         }
     }
 }
@@ -226,23 +227,23 @@ namespace Divergent.Customers.Handlers
     public class OrderSubmittedHandler : IHandleMessages<OrderSubmittedEvent>
     {
         private static readonly ILog Log = LogManager.GetLogger<OrderSubmittedHandler>();
-    
+
         public async Task Handle(OrderSubmittedEvent message, NServiceBus.IMessageHandlerContext context)
         {
             Log.Info("Handling: OrderSubmittedEvent.");
-    
+
             using (var db = new CustomersContext())
             {
                 var customer = await db.Customers
                     .Include(c=>c.Orders)
                     .SingleAsync(c=>c.Id == message.CustomerId);
-    
+
                 customer.Orders.Add(new Data.Models.Order()
                 {
                     CustomerId = message.CustomerId,
                     OrderId = message.OrderId
                 });
-    
+
                 await db.SaveChangesAsync();
             }
         }
@@ -320,6 +321,7 @@ namespace Divergent.Shipping.Handlers
         public async Task Handle(PaymentSucceededEvent message, IMessageHandlerContext context)
         {
             Log.Info("Handle");
+            await Task.CompletedTask;
         }
     }
 }
@@ -346,7 +348,7 @@ Our documentation contains more information about [auditing messages](https://do
 
 ### Step 2
 
-Verify that the audit and error queues have been created. You can use Windows Computer Management for this. Press <kbd>Win</kbd>+<kbd>X</kbd> to open the Windows system menu and select 'Computer Management'. You should see the queues Under "Service and Applications", "Message Queueing", "Private Queues". 
+Verify that the audit and error queues have been created. You can use Windows Computer Management for this. Press <kbd>Win</kbd>+<kbd>X</kbd> to open the Windows system menu and select 'Computer Management'. You should see the queues Under "Service and Applications", "Message Queueing", "Private Queues".
 
 NOTE: The MSMQ MMC snap-in is very limited in functionality. [QueueExplorer](http://www.cogin.com/mq/) is a great tool which provides much more.
 
@@ -370,7 +372,7 @@ Let's install the ServiceControl [heartbeat plugin]((https://docs.particular.net
 
 ### Step 6
 
-The heartbeat plugin sends messages directly to the ServiceControl queue rather than using the audit or error queues. The documentation shows how to configure the endpoint and tell it which queue it should send heartbeat messages to. 
+The heartbeat plugin sends messages directly to the ServiceControl queue rather than using the audit or error queues. The documentation shows how to configure the endpoint and tell it which queue it should send heartbeat messages to.
 
 You can find out the name of the queue by accessing the 'ServiceControl Management' app in the Windows Start menu. The name of the instance is also the name of the queue.
 

--- a/exercises/02-publish-subscribe/after/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/02-publish-subscribe/after/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/02-publish-subscribe/after/Divergent.Shipping/Handlers/OrderSubmittedHandler.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Shipping/Handlers/OrderSubmittedHandler.cs
@@ -17,6 +17,8 @@ namespace Divergent.Shipping.Handlers
             // If payment succeeds, we store that as well.
             //
             // When orders are paid before 12am, they will be shipped and arrive the next business day.
+
+            await Task.CompletedTask;
         }
     }
 }

--- a/exercises/02-publish-subscribe/after/Divergent.Shipping/Handlers/PaymentSucceededHandler.cs
+++ b/exercises/02-publish-subscribe/after/Divergent.Shipping/Handlers/PaymentSucceededHandler.cs
@@ -17,6 +17,8 @@ namespace Divergent.Shipping.Handlers
             // The order incl. products should also already have arrived and stored in database as well.
             //
             // When orders are paid before 12am, they will be shipped and arrive the next business day.
+
+            await Task.CompletedTask;
         }
     }
 }

--- a/exercises/02-publish-subscribe/before/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/02-publish-subscribe/before/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/03-sagas/after/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/03-sagas/after/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/03-sagas/before/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/03-sagas/before/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/03-sagas/before/Divergent.Shipping/Handlers/OrderSubmittedHandler.cs
+++ b/exercises/03-sagas/before/Divergent.Shipping/Handlers/OrderSubmittedHandler.cs
@@ -15,6 +15,8 @@ namespace Divergent.Shipping.Handlers
 
             // Store in database that order was submitted and which products belong to it.
             // Look at all pending orders, paid and ready to be shipped, in batches to decide what to ship.
+
+            await Task.CompletedTask;
         }
     }
 }

--- a/exercises/03-sagas/before/Divergent.Shipping/Handlers/PaymentSucceededHandler.cs
+++ b/exercises/03-sagas/before/Divergent.Shipping/Handlers/PaymentSucceededHandler.cs
@@ -15,6 +15,8 @@ namespace Divergent.Shipping.Handlers
 
             // Store in database that order was successfully paid.
             // Look at all pending orders, paid and ready to be shipped, in batches to decide what to ship.
+
+            await Task.CompletedTask;
         }
     }
 }

--- a/exercises/04-integration/after/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/04-integration/after/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/exercises/04-integration/before/Divergent.Frontend/Divergent.Frontend.csproj
+++ b/exercises/04-integration/before/Divergent.Frontend/Divergent.Frontend.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <Use64BitIISExpress />
+    <NoWarn>2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This removes all the redundant compiler warnings.

Three compiler warnings are still shown for the before solutions, but they are valid, until the exercises have been completed:

- > CSC : warning CS2008: No source files specified. [C:\code\Particular\Workshop.Microservices\exercises\02-publish-subscr ibe\before\Divergent.Finance.Messages\Divergent.Finance.Messages.csproj]

- > CSC : warning CS2008: No source files specified. [C:\code\Particular\Workshop.Microservices\exercises\04-integration\be fore\Divergent.ITOps.Messages\Divergent.ITOps.Messages.csproj]

- > Sagas\ShippingSaga.cs(45,28): warning CS1998: This async method lacks 'await' operators and will run synchronously. Con sider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a ba ckground thread. [C:\code\Particular\Workshop.Microservices\exercises\04-integration\before\Divergent.Shipping\Divergen t.Shipping.csproj]